### PR TITLE
fuse: support linking with FUSE-T

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -172,6 +172,8 @@ static void *cgofuse_init_fuse(void)
 	h = dlopen("/usr/local/lib/libfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse >= v4
 	if (0 == h)
 		h = dlopen("/usr/local/lib/libosxfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse < v4
+	if (0 == h)
+		h = dlopen("/usr/local/lib/libfuse-t.dylib", RTLD_NOW); // FUSE-T
 #elif defined(__FreeBSD__)
 	h = dlopen("libfuse.so.2", RTLD_NOW);
 #elif defined(__NetBSD__)


### PR DESCRIPTION
This is a formal PR for this change: https://github.com/macos-fuse-t/fuse-t/issues/4#issuecomment-1256639201
@11bw and I briefly tested this on macOS 13.0 Ventura with the FUSE-T 1.0.5.
Our project built and mounted successfully.