### PR TITLE
fuse: include FUSE-T header path

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -16,7 +16,7 @@
 package fuse
 
 /*
-#cgo darwin CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -I/usr/local/include/osxfuse/fuse
+#cgo darwin CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -I/usr/local/include/osxfuse/fuse -I/usr/local/include/fuse
 #cgo freebsd CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -I/usr/local/include/fuse
 #cgo netbsd CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64 -D_KERNTYPES
 #cgo openbsd CFLAGS: -DFUSE_USE_VERSION=28 -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
Amendment to https://github.com/winfsp/cgofuse/pull/73
Now, FUSE-T headers should (always) be in `/usr/local/include/fuse`.
Previously, they could (sometimes) end up in `/usr/local/include` which didn't require specifying the path for most compilers.

---

As an aside, the Go tests on macOS fail with FUSE-T, but programs built with this branch (the examples and external projects) have been working in practice.
Not sure why that's the case.