### PR TITLE
fuse: search a list of paths for `fusermount` executable

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -634,9 +634,21 @@ static int hostUnmount(struct fuse *fuse, char *mountpoint)
 	if (0 == umount2(mountpoint, MNT_DETACH))
 		return 1;
 	// linux: umount2 failed; try fusermount
-	char *argv[] =
+	char *paths[] =
 	{
 		"/bin/fusermount",
+		"/usr/bin/fusermount",
+	};
+	char *path = paths[0];
+	for (size_t i = 0; sizeof paths / sizeof paths[0] > i; i++)
+		if (0 == access(paths[i], X_OK))
+		{
+			path = paths[i];
+			break;
+		}
+	char *argv[] =
+	{
+		path,
 		"-z",
 		"-u",
 		mountpoint,


### PR DESCRIPTION
The distribution I'm using (Gentoo) places `fusermount` in `/usr/bin` rather than `/bin`.
As a result, `host.Unmount()` returns `false` (on my system the call stack is: `posix_spawn`->`clone`->`ENOENT`)
Since the call to `Unmount` fails, `host.Mount()` will continue to block.

This patch replaces `posix_spawn` with `posix_spawnp` and changes the actual-parameter to just be the executable name `"fusermount"`.
`posix_spawnp` uses a formal-parameter `file` instead of `path`, and searches `$PATH` to find a location for `file`. (https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn.html)
Which should spawn a user's preferred `fusermount` executable, regardless of where it resides (as long as it actually exists within a directory contained in `$PATH`)