### PR TITLE
added nlink attribute to stat in hellofs example

### DIFF
--- a/examples/hellofs/hellofs.go
+++ b/examples/hellofs/hellofs.go
@@ -40,10 +40,12 @@ func (self *Hellofs) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc in
 	switch path {
 	case "/":
 		stat.Mode = fuse.S_IFDIR | 0555
+		stat.Nlink = 2
 		return 0
 	case "/" + filename:
 		stat.Mode = fuse.S_IFREG | 0444
 		stat.Size = int64(len(contents))
+		stat.Nlink = 1
 		return 0
 	default:
 		return -fuse.ENOENT


### PR DESCRIPTION
these assigments were missing compared to the original c examples in https://github.com/libfuse/libfuse/blob/master/example/hello.c#L63

as a result, the fuse mount is not visible if its in a samba share accessed from a windows computer
(even if option "allow_other" is set)
[this issue](https://github.com/hanwen/go-fuse/issues/424) helped me found it